### PR TITLE
ci: reduce GitHub Actions runner usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Test supported Python versions
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,19 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.9","3.10","3.11","3.12"]') }}
       fail-fast: false
 
     defaults:
@@ -32,9 +38,6 @@ jobs:
       - name: Install Flit
         if: steps.cache.outputs.cache-hit != 'true'
         run: bash dev/setup.sh
-#      - name: Lint
-#        run: |
-#          pre-commit run --all-files
       - name: Run tests
         run: bash dev/test_python.sh
       - name: Test installation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,33 +14,29 @@ concurrency:
 jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    name: Test supported Python versions
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.9","3.10","3.11","3.12"]') }}
-      fail-fast: false
-
     defaults:
       run:
         shell: bash
-
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v5
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-test
-      - name: Install Flit
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bash dev/setup.sh
-      - name: Run tests
-        run: bash dev/test_python.sh
-      - name: Test installation
+          enable-cache: true
+      - name: Install supported Python versions
+        run: uv python install 3.9 3.10 3.11 3.12
+      - name: Run tests across Python versions in parallel
         run: |
-          pip install -e .
-          python -c 'import lightdash_client; print(lightdash_client.__version__)'
+          set -euo pipefail
+          nox_spec='nox[uv]==2026.7.11'
+          uvx --from "${nox_spec}" nox --list >/dev/null
+          printf '%s\0' 3.9 3.10 3.11 3.12 \
+            | xargs -0 -P "$(nproc)" -I{} \
+                uvx --from "${nox_spec}" nox --session "tests-{}"
+      - name: Test installation on primary Python
+        run: |
+          uv venv --python 3.12
+          uv pip install -e .
+          uv run python -c 'import lightdash_client; print(lightdash_client.__version__)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,8 @@ jobs:
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
-      - name: Install supported Python versions
-        run: uv python install 3.9 3.10 3.11 3.12
-      - name: Run tests across Python versions in parallel
-        run: |
-          set -euo pipefail
-          nox_spec='nox[uv]==2026.7.11'
-          uvx --from "${nox_spec}" nox --list >/dev/null
-          printf '%s\0' 3.9 3.10 3.11 3.12 \
-            | xargs -0 -P "$(nproc)" -I{} \
-                uvx --from "${nox_spec}" nox --session "tests-{}"
+      - name: Run compatibility tests
+        run: uv run --with "nox[uv]==2026.7.11" bash dev/test_all.sh
       - name: Test installation on primary Python
         run: |
           uv venv --python 3.12

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ lint:
 test:
 	bash ./dev/test_python.sh
 
+# Run the complete supported-Python suite through the same entrypoint as CI.
+.PHONY: test-all
+test-all:
+	uv run --with "nox[uv]==2026.7.11" bash ./dev/test_all.sh
+
 # Build the package
-build: clean lint test
+build: clean lint test-all
 	flit build
 
 clean:

--- a/dev/test_all.sh
+++ b/dev/test_all.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+cd "${REPO_ROOT}"
+
+exec nox --tags ci "$@"

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,9 +7,11 @@ import nox
 PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
 
 nox.options.default_venv_backend = "uv"
+nox.options.download_python = "auto"
+nox.options.reuse_venv = "yes"
 
 
-@nox.session(python=PYTHON_VERSIONS)
+@nox.session(python=PYTHON_VERSIONS, tags=["ci"])
 def tests(session: nox.Session) -> None:
     """Run the Flit-based test suite in an isolated uv-backed environment."""
     session.install("pip", "flit==3.9.0")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,17 @@
+"""Nox sessions for supported Python versions."""
+
+from __future__ import annotations
+
+import nox
+
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+
+nox.options.default_venv_backend = "uv"
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def tests(session: nox.Session) -> None:
+    """Run the Flit-based test suite in an isolated uv-backed environment."""
+    session.install("pip", "flit==3.9.0")
+    session.run("flit", "install", "--deps", "develop", "--symlink")
+    session.run("bash", "dev/test_python.sh", external=True)


### PR DESCRIPTION
## Summary

Keep the complete supported Python range as pre-merge coverage while removing compatibility orchestration from GitHub Actions.

- `noxfile.py` owns supported versions and uv-backed isolated environments while preserving the project's Flit development-install semantics
- `dev/test_all.sh` is a tiny tagged-Nox wrapper; `make test-all` is the local entrypoint
- GitHub Actions has no Python-version matrix or shell session-name construction
- installation/import validation runs once on the primary Python environment
- cancellation remains; triggered validation is not suppressed for draft PRs

Future supported-version changes are localized to Nox.